### PR TITLE
Finish configure flyway for auto database migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,9 @@ dependencies {
 	// spring-webflux
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 
+	// flywaydb-migration
+	implementation("org.flywaydb:flyway-core")
+
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	runtimeOnly("com.h2database:h2")
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/kotlin/com/geogrind/geogrindbackend/config/database/DatabaseConfig.kt
+++ b/src/main/kotlin/com/geogrind/geogrindbackend/config/database/DatabaseConfig.kt
@@ -1,4 +1,4 @@
-package com.geogrind.geogrindbackend.config
+package com.geogrind.geogrindbackend.config.database
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/src/main/kotlin/com/geogrind/geogrindbackend/config/database/DatabaseConfigImpl.kt
+++ b/src/main/kotlin/com/geogrind/geogrindbackend/config/database/DatabaseConfigImpl.kt
@@ -1,4 +1,4 @@
-package com.geogrind.geogrindbackend.config
+package com.geogrind.geogrindbackend.config.database
 
 import io.github.cdimascio.dotenv.Dotenv
 import org.springframework.context.annotation.Bean

--- a/src/main/kotlin/com/geogrind/geogrindbackend/config/flyway/FlywayConfig.kt
+++ b/src/main/kotlin/com/geogrind/geogrindbackend/config/flyway/FlywayConfig.kt
@@ -1,0 +1,13 @@
+package com.geogrind.geogrindbackend.config.flyway
+
+import org.flywaydb.core.Flyway
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.sql.DataSource
+
+@Configuration
+interface FlywayConfig {
+    @Bean
+    fun flyway(@Qualifier("dataSource") dataSource: DataSource): Flyway
+}

--- a/src/main/kotlin/com/geogrind/geogrindbackend/config/flyway/FlywayConfigImpl.kt
+++ b/src/main/kotlin/com/geogrind/geogrindbackend/config/flyway/FlywayConfigImpl.kt
@@ -1,0 +1,20 @@
+package com.geogrind.geogrindbackend.config.flyway
+
+import org.flywaydb.core.Flyway
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.sql.DataSource
+
+@Configuration
+class FlywayConfigImpl : FlywayConfig {
+    @Bean
+    override fun flyway(dataSource: DataSource): Flyway {
+        val flyway: Flyway = Flyway.configure()
+            .dataSource(dataSource)
+            .locations("classpath:resources/db.migration")
+            .baselineOnMigrate(true) // Add this line to baseline the schema
+            .load()
+        flyway.migrate()
+        return flyway
+    }
+}


### PR DESCRIPTION
**### The dataSource for the database with the migration is configured with a Bean annotation for auto detected the migration if there is any change to the database.**

**### How to test the migration:**:

1. Note: This should not be touched unless there is a migration required for the database. 
2. Go into the src/main/resources/db.migration folder and create a sql file, name it: V2__updated_{migration_field}.sql 
3. Restart and run the server as FlyWay Bean will auto detect the change and run the migration script needed.